### PR TITLE
Merge feat/features-without-scaler

### DIFF
--- a/common/src/main/kotlin/io/rightpad/daxplorer/data/features/FeatureConfig.kt
+++ b/common/src/main/kotlin/io/rightpad/daxplorer/data/features/FeatureConfig.kt
@@ -4,7 +4,7 @@ import io.rightpad.daxplorer.data.scalers.Scaler
 
 interface FeatureConfig<
         F: Feature<*>,
-        S: Scaler<*, *, *>> {
+        S: Scaler<*, *, *>?> {
     fun createFeature(): F
     fun createScaler(): S
 }

--- a/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/Main.kt
+++ b/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/Main.kt
@@ -73,9 +73,9 @@ class Main {
             }
         }
 
-        private fun buildScalersList(args: Args): List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>> {
+        private fun buildScalersList(args: Args): List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?> {
             val featureColumnScalers = args.config.features?.map {
-                it.createScaler() as Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>
+                it.createScaler() as Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?
             } ?: listOf()
 
             return listOf(IndexDataPointScaler() as Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>)
@@ -83,7 +83,7 @@ class Main {
         }
 
         private fun initializeScalers(
-                scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>>,
+                scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?>,
                 args: Args,
                 compiledData: List<List<TimeSeriesDataPoint?>>
         ) {

--- a/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/scaling/build_scaler_configuration.kt
+++ b/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/scaling/build_scaler_configuration.kt
@@ -8,7 +8,7 @@ import io.rightpad.daxplorer.data.scalers.Scaler
 import io.rightpad.daxplorer.data_compiler.ScalerConfig
 
 fun buildScalerConfiguration(
-        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>>
+        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?>
 ): ScalerConfig {
     val indexDataPointScalerConfigs = scalers.mapNotNull { it as? IndexDataPointScaler }
             .map { scaler -> scaler.buildConfig() }

--- a/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/scaling/configure_scalers.kt
+++ b/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/scaling/configure_scalers.kt
@@ -6,7 +6,7 @@ import io.rightpad.daxplorer.data_compiler.ScalerConfig
 
 fun applyScalerConfiguration(
         config: ScalerConfig,
-        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>>
+        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?>
 ) {
     applyIndexDataPointScalerConfig(config, scalers)
     applyMoneyScalerConfig(config, scalers)
@@ -14,7 +14,7 @@ fun applyScalerConfiguration(
 
 private fun applyIndexDataPointScalerConfig(
         config: ScalerConfig,
-        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>>
+        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?>
 ) {
     val indexDataPointScalerConfig = IndexDataPointScalerConfig(
             startScalerConfig = config.moneyScalerConfig,
@@ -29,7 +29,7 @@ private fun applyIndexDataPointScalerConfig(
 
 fun applyMoneyScalerConfig(
         config: ScalerConfig,
-        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>>
+        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?>
 ) {
     scalers.mapNotNull { it as? AverageDataPointScaler }
             .forEach { it.configure(config.moneyScalerConfig) }

--- a/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/scaling/scale.kt
+++ b/data-compiler/src/main/kotlin/io/rightpad/daxplorer/data_compiler/scaling/scale.kt
@@ -5,11 +5,11 @@ import io.rightpad.daxplorer.data.scalers.Scaler
 
 fun scale(
         compiledData: List<List<TimeSeriesDataPoint?>>,
-        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>>
+        scalers: List<Scaler<TimeSeriesDataPoint, TimeSeriesDataPoint, Any>?>
 ): List<List<TimeSeriesDataPoint?>> {
     val scaledData = compiledData.map { row ->
         row.mapIndexed { i, featureDataPoint ->
-            if(featureDataPoint != null) scalers[i].scale(featureDataPoint)
+            if(featureDataPoint != null) scalers[i]?.scale(featureDataPoint) ?: featureDataPoint
             else null
         }
     }


### PR DESCRIPTION
Added support for unscaled features

Unscaled features are features that have no scaler (because they
already are relative). Instead of a scaled value, the scaled output
will just contain the regular feature value for an unscaled feature.